### PR TITLE
Add Github pull request URL's to Trello Cards

### DIFF
--- a/lib/rmt/github_source.rb
+++ b/lib/rmt/github_source.rb
@@ -12,9 +12,15 @@ module RMT
       target_list = trello.target_list_id
       pull_requests = @github.pull_requests.all(@config.user, @config.repo, :per_page => 100)
       pull_requests.collect do |pr|
+        custom_pr_body = <<-EOBODY
+Links: [Pull Request #{pr.number} Discussion](#{pr.html_url}) and
+[File Diff](#{pr.html_url}/files)
+
+#{pr.body}
+        EOBODY
         RMT::SynchronizationData.new("PR #{@config.repo}/#{pr.number}",
                                      pr.title,
-                                     pr.body,
+                                     custom_pr_body,
                                      target_list,
                                      "blue",
                                      proc { |trello| trello.all_cards_on_board_of(target_list) })


### PR DESCRIPTION
Without this patch the trello cards created by this project don't
actually contain clickable URL's.  This makes things a bit annoying to
actually see and review pull requests quickly.

This patch addresses the problem by modifying the generated body of each
card.  Each body now contains two clickable links, one to the pull
request main landing page, and one to the file diff ready for
commentary.
