### PR TITLE
Add Github OAuth token support to avoid rate limits

### DIFF
--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -60,11 +60,12 @@ module RMT
     end
 
     class GithubConfig
-      attr_reader :user, :repo
+      attr_reader :user, :repo, :oauth_token
 
       def initialize(definition)
         @user = definition[:user]
         @repo = definition[:repo]
+        @oauth_token = definition[:oauth_token]
       end
     end
 

--- a/lib/rmt/github_source.rb
+++ b/lib/rmt/github_source.rb
@@ -4,7 +4,7 @@ require 'rmt/synchronization_data'
 module RMT
   class GithubSource
     def initialize(github_config)
-      @github = Github.new
+      @github = Github.new(:oauth_token => github_config.oauth_token)
       @config = github_config
     end
 


### PR DESCRIPTION
Without this patch applied the implementation does not use any
authentication when communicating with the Github API.  This is a
problem because Github has very low rate limits (100/hour) for
unauthenticated requests.

This patch addresses the problem by accepting a Github OAuth token as a
configuration parameter.  Using this token increases the rate limit to
5000 requests per hour.

A token may be obtained like so:

```
GITHUB_USER=gepetto-bot
curl -u $GITHUB_USER -d '
{
  "scopes":["repo"],
  "note":"redmine-trello",
  "note_url":"https://github.com/cprice-puppet/redmine-trello"
}' https://api.github.com/authorizations
```

A token may be revoked at https://github.com/settings/applications
