### PR TITLE
Check all lists

### DIFF
--- a/config/redmine_trello_conf.rb.SAMPLE
+++ b/config/redmine_trello_conf.rb.SAMPLE
@@ -3,6 +3,10 @@ RMT::Config.define("sample") do
 		:base_url => "https://projects.puppetlabs.com/",
 		:username => "user@puppetlabs.com",
 		:password => "password",
+		# Where should we check for existing tickets?
+		# if true - on the whole board,
+		# if false - just check on the target list.
+		:check_all_lists => false,
 		# Redmine project ID can be found from, e.g., http://projects.puppetlabs.com/projects.xml
 		:project_id => 82
 	})

--- a/lib/rmt/config.rb
+++ b/lib/rmt/config.rb
@@ -49,13 +49,14 @@ module RMT
     end
 
     class RedmineConfig
-      attr_reader :base_url, :username, :password, :project_id
+      attr_reader :base_url, :username, :password, :project_id, :check_all_lists
 
       def initialize(definition)
         @base_url = definition[:base_url]
         @username = definition[:username]
         @password = definition[:password]
         @project_id = definition[:project_id]
+        @check_all_lists = definition[:check_all_lists]
       end
     end
 

--- a/lib/rmt/redmine_source.rb
+++ b/lib/rmt/redmine_source.rb
@@ -23,7 +23,7 @@ module RMT
           ticket[:description],
           target_list,
           trello.color_map[ticket[:tracker]],
-          proc { |trello| trello.list_cards_in(target_list) })
+          proc { |trello| trello.all_cards_on_board_of(target_list) })
       end
     end
   end

--- a/lib/rmt/redmine_source.rb
+++ b/lib/rmt/redmine_source.rb
@@ -12,13 +12,19 @@ module RMT
 
     def data_for(trello)
       target_list = trello.target_list_id
-      issues = @redmine_client.get_issues_for_project(@project_id, :status => RMT::Redmine::Status::Unreviewed)
-      issues.collect { |ticket| SynchronizationData.new(ticket[:id],
-                                                        ticket[:subject],
-                                                        ticket[:description],
-                                                        target_list,
-                                                        trello.color_map[ticket[:tracker]],
-                                                        proc { |trello| trello.list_cards_in(target_list) }) }
+      issues = @redmine_client.get_issues_for_project(
+        @project_id,
+        :status => RMT::Redmine::Status::Unreviewed
+      )
+      issues.collect do |ticket|
+        SynchronizationData.new(
+          ticket[:id],
+          ticket[:subject],
+          ticket[:description],
+          target_list,
+          trello.color_map[ticket[:tracker]],
+          proc { |trello| trello.list_cards_in(target_list) })
+      end
     end
   end
 end


### PR DESCRIPTION
Added a setting in the Redmine section called :check_all_lists.
If true, before creating tickets on Trello, all lists on the board are checked. If false, only the target list is checked.
